### PR TITLE
Add ProcessTime attribute to the RemoteJsonLogger layout.

### DIFF
--- a/Lokad.Logging/Tracer.cs
+++ b/Lokad.Logging/Tracer.cs
@@ -106,6 +106,7 @@ namespace Lokad.Logging
                     Attributes =
                     {
                         new JsonAttribute("Timestamp", "${longdate}"),
+                        new JsonAttribute("ProcessTime", "${processtime}"),
                         new JsonAttribute("ApiKey", apiKey),
                         new JsonAttribute("Application", application),
                         new JsonAttribute("Environment", environment),

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ an [NLogNetwork target](https://github.com/NLog/NLog/wiki/Network-target) pointi
 to the given server with a [JsonLayout](https://github.com/NLog/NLog/wiki/JsonLayout).  
 The JsonLayout will push the following attributes with the corresponding layouts:
 - Timestamp ([${longdate}](https://github.com/NLog/NLog/wiki/LongDate-Layout-Renderer))
+- ProcessTime ([${processtime}](https://github.com/NLog/NLog/wiki/ProcessTime-Layout-Renderer))
 - ApiKey (the key provided in the method call).
 - Application (the application provided in the method call).
 - Environment (the runtime environment provided in the method call).


### PR DESCRIPTION
This will add the ProcessTime to the json payload sent to the remote
server.